### PR TITLE
Only request key press for debug builds

### DIFF
--- a/SolutionDependencyAnalyzer/Program.cs
+++ b/SolutionDependencyAnalyzer/Program.cs
@@ -53,8 +53,11 @@ namespace SolutionDependencyAnalyzer
                 markdownWriter.WriteProjectDependenciesByPackage(dependencyAnalyzer.ProjectsByPackage)
             };
             await Task.WhenAll(tasks).ConfigureAwait(false);
-            Console.WriteLine("Done. Press any key to exit.");
+            Console.WriteLine("Done.");
+#if DEBUG
+            Console.WriteLine("Press any key to exit.");
             Console.ReadKey();
+#endif
         }
     }
 }


### PR DESCRIPTION
Release builds will exit the application directly, so they can be used in scripts.

Fixes issue #2