### PR TITLE
ADD options to exclude specific projects and to exclude all *test* projects

### DIFF
--- a/SolutionDependencyAnalyzer/Program.cs
+++ b/SolutionDependencyAnalyzer/Program.cs
@@ -20,7 +20,7 @@ namespace SolutionDependencyAnalyzer
         [Option("-g|--create-graph-image", Description = "Runs dot to create a png from the dotfile. Make sure to have dot installed before activating this option")]
         public bool WriteGraph { get; set; }
 
-        [Option("--exclude-test-projects", Description = "Excludes test projects from analysis. A test project is anything with \"test\" in its name.")]
+        [Option("-t|--exclude-test-projects", Description = "Excludes test projects from analysis. A test project is anything with \"test\" in its name.")]
         public bool ExcludeTestProjects { get; set; }
 
         [Option("-x|--exclude-project", Description = "Excludes a specific project from analysis")]

--- a/SolutionDependencyAnalyzer/Program.cs
+++ b/SolutionDependencyAnalyzer/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Threading.Tasks;
@@ -18,6 +19,12 @@ namespace SolutionDependencyAnalyzer
 
         [Option("-g|--create-graph-image", Description = "Runs dot to create a png from the dotfile. Make sure to have dot installed before activating this option")]
         public bool WriteGraph { get; set; }
+
+        [Option("--exclude-test-projects", Description = "Excludes test projects from analysis. A test project is anything with \"test\" in its name.")]
+        public bool ExcludeTestProjects { get; set; }
+
+        [Option("-x|--exclude-project", Description = "Excludes a specific project from analysis")]
+        public string[] ProjectsToExclude { get; set; }
 
         public static Task<int> Main(string[] args)
         {
@@ -43,7 +50,7 @@ namespace SolutionDependencyAnalyzer
         private async Task OnExecuteAsync()
         {
             var dependencyAnalyzer = new DependencyAnalyzer(Solution!);
-            await dependencyAnalyzer.AnalyzeAsync().ConfigureAwait(false);
+            await dependencyAnalyzer.AnalyzeAsync(ExcludeTestProjects, ProjectsToExclude).ConfigureAwait(false);
 
             var markdownWriter = new MarkdownWriter(OutputPath!);
             var dotWriter = new DotWriter(OutputPath!);


### PR DESCRIPTION
Hello,

this PR adds 2 options to commandline:
1. "-x|--exclude-project" to exclude a specific project from analysis. Multiple -x can be specified.
2. "-t|--exclude-test-projects" to exclude all test-like projects. Test projects are identified just by looking at their name containing "test".

e.g. args: "C:\path\to\sln\My.sln" . -x My.Project.ToExclude --exclude-test-projects